### PR TITLE
Implement timeout for staging & production deployment jobs

### DIFF
--- a/.github/workflows/default-deploy-template.yml
+++ b/.github/workflows/default-deploy-template.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   deploy-staging:
-    timeout-minutes: 3
+    timeout-minutes: 2
     name: "Staging"
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest    
@@ -552,7 +552,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_DEPLOYMENT_BOT_TOKEN }}
 
   deploy-production:
-    timeout-minutes: 3
+    timeout-minutes: 2
     name: "Production"
     if: github.event_name == 'push' && github.ref_name == 'main'
     runs-on: ubuntu-latest

--- a/.github/workflows/default-deploy-template.yml
+++ b/.github/workflows/default-deploy-template.yml
@@ -28,6 +28,7 @@ env:
 
 jobs:
   deploy-staging:
+    timeout-minutes: 3
     name: "Staging"
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest    
@@ -551,6 +552,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_DEPLOYMENT_BOT_TOKEN }}
 
   deploy-production:
+    timeout-minutes: 3
     name: "Production"
     if: github.event_name == 'push' && github.ref_name == 'main'
     runs-on: ubuntu-latest

--- a/.github/workflows/default-deploy-template.yml
+++ b/.github/workflows/default-deploy-template.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   deploy-staging:
-    timeout-minutes: 2
+    timeout-minutes: 30
     name: "Staging"
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest    
@@ -552,7 +552,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_DEPLOYMENT_BOT_TOKEN }}
 
   deploy-production:
-    timeout-minutes: 2
+    timeout-minutes: 30
     name: "Production"
     if: github.event_name == 'push' && github.ref_name == 'main'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Implement 30-minute timeout for both staging and production deployments

Tested here with 3-min timeout: https://github.com/arg-tech/hello-arg-tech/pull/4

Interestingly, it doesn't time out immediately, and the job usually takes a few more seconds (~10 secs) to terminate. So, to make sure it's not a coincidence and the time-out actually works, I tested it with a 2 min-timeout as well. It all worked!